### PR TITLE
Improve search relevance matching

### DIFF
--- a/app/app.iml
+++ b/app/app.iml
@@ -9,13 +9,9 @@
     <facet type="android" name="Android">
       <configuration>
         <option name="SELECTED_BUILD_VARIANT" value="debug" />
-        <option name="SELECTED_TEST_ARTIFACT" value="_android_test_" />
         <option name="ASSEMBLE_TASK_NAME" value="assembleDebug" />
         <option name="COMPILE_JAVA_TASK_NAME" value="compileDebugSources" />
-        <option name="ASSEMBLE_TEST_TASK_NAME" value="assembleDebugAndroidTest" />
-        <option name="COMPILE_JAVA_TEST_TASK_NAME" value="compileDebugAndroidTestSources" />
         <afterSyncTasks>
-          <task>generateDebugAndroidTestSources</task>
           <task>generateDebugSources</task>
         </afterSyncTasks>
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
@@ -28,19 +24,21 @@
   </component>
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_6" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/build/intermediates/classes/debug" />
-    <output-test url="file://$MODULE_DIR$/build/intermediates/classes/androidTest/debug" />
+    <output-test url="file://$MODULE_DIR$/build/intermediates/classes/test/debug" />
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/debug" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/debug" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/debug" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/debug" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/debug" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/debug" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/androidTest/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/androidTest/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/androidTest/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/androidTest/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/androidTest/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/androidTest/debug" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/androidTest/debug" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/res" type="java-resource" />
@@ -48,32 +46,47 @@
       <sourceFolder url="file://$MODULE_DIR$/src/debug/assets" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/aidl" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/java" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/debug/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/rs" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/debug/shaders" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/assets" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/aidl" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/main/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-safeguard" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/shaders" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/transforms" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
@@ -81,5 +94,11 @@
     </content>
     <orderEntry type="jdk" jdkName="Android API 15 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" exported="" scope="TEST" name="runner-0.5" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="exposed-instrumentation-api-publish-0.5" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="hamcrest-core-1.3" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="rules-0.5" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="junit-4.12" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="support-annotations-25.3.1" level="project" />
   </component>
 </module>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,12 +2,13 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 15
-    buildToolsVersion "23.0.2"
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         applicationId "com.hewgill.android.nzsldict"
         minSdkVersion 9
         targetSdkVersion 15
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -15,5 +16,11 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
+    }
+
+    dependencies {
+        androidTestCompile 'com.android.support:support-annotations:25.3.1'
+        androidTestCompile 'com.android.support.test:runner:0.5'
+        androidTestCompile 'com.android.support.test:rules:0.5'
     }
 }

--- a/app/src/androidTest/java/DictionaryAndroidUnitTest.java
+++ b/app/src/androidTest/java/DictionaryAndroidUnitTest.java
@@ -1,0 +1,73 @@
+import android.support.test.filters.SmallTest;
+import android.support.test.runner.AndroidJUnit4;
+
+import com.hewgill.android.nzsldict.Dictionary;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+
+import static android.support.test.InstrumentationRegistry.getInstrumentation;
+import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+@RunWith(AndroidJUnit4.class)
+@SmallTest
+public class DictionaryAndroidUnitTest {
+    private Dictionary mDictionary;
+    private List<Dictionary.DictItem> mResults;
+
+    @Before
+    public void createDictionary() {
+        mDictionary = new Dictionary(getInstrumentation().getTargetContext());
+    }
+
+    @After
+    public void clearResults() {
+        mResults = null;
+    }
+
+    @Test
+    public void dictionary_getWordsContainsWords() {
+        assertNotEquals(mDictionary.getWords().size(), 0);
+    }
+
+    @Test
+    public void dictionary_getWordsExactMatchMainGloss() {
+        mResults = mDictionary.getWords("Book");
+        assertEquals(mResults.get(0).gloss, "book");
+    }
+
+    @Test
+    public void dictionary_getWordsContainsMatchMainGlass() {
+        mResults = mDictionary.getWords("las");
+        assertEquals(mResults.get(0).gloss, "sunglasses");
+    }
+
+    @Test
+    public void dictionary_getWordsExactMatchMaoriGloss() {
+        mResults = mDictionary.getWords("ora");
+        assertEquals(mResults.get(0).gloss, "alive, live, survive");
+    }
+
+    @Test
+    public void dictionary_getWordsContainsMatchMaoriGloss() {
+        mResults = mDictionary.getWords("orang");
+        assertEquals(mResults.get(0).gloss, "politics");
+    }
+
+    @Test
+    public void dictionary_getWordsExactSecondaryGloss() {
+        mResults = mDictionary.getWords("nought");
+        assertEquals(mResults.get(0).gloss, "zero");
+    }
+
+    @Test
+    public void dictionary_getWordsContainsSecondaryGloss() {
+        mResults = mDictionary.getWords("keep ou");
+        assertEquals(mResults.get(0).gloss, "want nothing to do with");
+    }
+}

--- a/app/src/main/java/com/hewgill/android/nzsldict/Dictionary.java
+++ b/app/src/main/java/com/hewgill/android/nzsldict/Dictionary.java
@@ -20,8 +20,14 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 public class Dictionary {
+
+    private static final Integer EXACT_PRIMARY_MATCH_WEIGHTING = 100;
+    private static final Integer CONTAINS_PRIMARY_MATCH_WEIGHTING = 80;
+    private static final Integer EXACT_SECONDARY_MATCH_WEIGHTING = 70;
+    private static final Integer CONTAINS_SECONDARY_MATCH_WEIGHTING = 60;
 
     public static class DictItem implements Serializable {
         public String gloss;
@@ -104,7 +110,7 @@ public class Dictionary {
 
     private ArrayList<DictItem> words = new ArrayList();
 
-    Dictionary(Context context)
+    public Dictionary(Context context)
     {
         InputStream db = null;
         try {
@@ -119,7 +125,7 @@ public class Dictionary {
                 words.add(new DictItem(a[0], a[1], a[2], a[3], a[4], a[5], a[6]));
             }
         } catch (IOException x) {
-            Log.d("dictionary", "exception reading from word list");
+            Log.d("dictionary", "exception reading from word list " + x.getMessage());
         } finally {
             if (db != null) {
                 try {
@@ -161,16 +167,27 @@ public class Dictionary {
 
     public List<DictItem> getWords(String target)
     {
-        List<DictItem> r = new ArrayList<DictItem>(words.size());
-        String t = normalise(target);
-        for (DictItem d: words) {
-            if (normalise(d.gloss).indexOf(t) >= 0
-             || normalise(d.minor).indexOf(t) >= 0
-             || normalise(d.maori).indexOf(t) >= 0) {
-                r.add(d);
+        TreeMap<Integer, DictItem> results = new TreeMap<Integer, DictItem>(new Comparator<Integer>() {
+            @Override
+            public int compare(Integer weight1, Integer weight2) {
+                return weight2.compareTo(weight1);
             }
+        });
+        String term = normalise(target);
+        for (DictItem d: words) {
+            String gloss = normalise(d.gloss);
+            String minor = normalise(d.minor);
+            String maori = normalise(d.maori);
+
+            if (gloss.equals(term) || maori.equals(term)) results.put(EXACT_PRIMARY_MATCH_WEIGHTING, d);
+            else if (gloss.contains(term) || maori.contains(term)) results.put(CONTAINS_PRIMARY_MATCH_WEIGHTING, d);
+            else if (minor.equals(term)) results.put(EXACT_SECONDARY_MATCH_WEIGHTING, d);
+            else if (minor.contains(term)) results.put(CONTAINS_SECONDARY_MATCH_WEIGHTING, d);
         }
-        return r;
+
+        Log.d("Results", results.toString());
+
+        return new ArrayList<DictItem>(results.values());
     }
 
     public List<DictItem> getWordsByHandshape(String handshape, String location)

--- a/app/src/main/java/com/hewgill/android/nzsldict/Dictionary.java
+++ b/app/src/main/java/com/hewgill/android/nzsldict/Dictionary.java
@@ -185,8 +185,6 @@ public class Dictionary {
             else if (minor.contains(term)) results.put(CONTAINS_SECONDARY_MATCH_WEIGHTING, d);
         }
 
-        Log.d("Results", results.toString());
-
         return new ArrayList<DictItem>(results.values());
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.3.2'
     }
 }
 
@@ -13,3 +13,5 @@ allprojects {
         jcenter()
     }
 }
+
+

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Oct 21 11:34:03 PDT 2015
+#Tue Jun 06 12:07:38 NZST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/nzsl-dictionary-android.iml
+++ b/nzsl-dictionary-android.iml
@@ -13,7 +13,7 @@
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.gradle" />
     </content>
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="1.8" jdkType="JavaSDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>


### PR DESCRIPTION
This pull request updates how searching is performed to prefer exact matches on major or Maori gloss before simple contains matches. It also sets up the app for connected instrument tests and adds tests asserting that the dictionary searching is applying the weighting rules requested by NZSL.

As yet there is no automated build set up, but in a set up Android development environment, the tests can be run by running `gradle connectedAndroidTest`. In the case that an Android dev environment is not available, I have attached a screenshot of the tests passing:

![screen shot 2017-06-07 at 10 36 52 am](https://user-images.githubusercontent.com/292020/26855112-639588b4-4b6d-11e7-95c1-044bbcb65f34.png)
