### PR TITLE
Show Maori gloss in search results and adjust typography and spacing

### DIFF
--- a/app/src/main/java/com/hewgill/android/nzsldict/NZSLDictionary.java
+++ b/app/src/main/java/com/hewgill/android/nzsldict/NZSLDictionary.java
@@ -1,6 +1,5 @@
 package com.hewgill.android.nzsldict;
 
-import android.app.Activity;
 import android.app.ListActivity;
 import android.content.Context;
 import android.content.Intent;
@@ -11,15 +10,12 @@ import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.Log;
 import android.view.LayoutInflater;
-import android.view.Menu;
-import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.AdapterView;
-import android.widget.BaseAdapter;
 import android.widget.ArrayAdapter;
+import android.widget.BaseAdapter;
 import android.widget.EditText;
 import android.widget.Filter;
 import android.widget.Gallery;
@@ -80,6 +76,7 @@ public class NZSLDictionary extends ListActivity
             }
             TextView gv = (TextView) v.findViewById(R.id.item_gloss);
             TextView mv = (TextView) v.findViewById(R.id.item_minor);
+            TextView mtv = (TextView) v.findViewById(R.id.item_maori);
             ImageView dv = (ImageView) v.findViewById(R.id.diagram);
             if (position >= getCount()) {
                 Log.e("filter", "request for item " + position + " in list of size " + getCount());
@@ -88,6 +85,8 @@ public class NZSLDictionary extends ListActivity
             Dictionary.DictItem item = getItem(position);
             gv.setText(item.gloss);
             mv.setText(item.minor);
+            mtv.setText(item.maori);
+
             try {
                 InputStream ims = getAssets().open(item.imagePath());
                 Drawable d = Drawable.createFromStream(ims, null);

--- a/app/src/main/res/layout/list_item.xml
+++ b/app/src/main/res/layout/list_item.xml
@@ -3,9 +3,14 @@
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:orientation="horizontal"
+    android:layout_marginTop="8dp"
+    android:paddingLeft="16dp"
+    android:paddingRight="16dp"
+    android:paddingTop="16dp"
+    android:paddingBottom="20dp"
     android:background="#fff">
     <LinearLayout
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="fill_parent"
         android:layout_weight="1"
         android:orientation="vertical">
@@ -14,9 +19,8 @@
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
             android:padding="1dp"
-            android:textSize="20sp"
-            android:textColor="#000"
-            android:textStyle="bold">
+            style="@style/Base.TextAppearance.AppCompat.Title">
+        </TextView>
         <TextView
             android:id="@+id/item_maori"
             android:layout_width="fill_parent"
@@ -29,12 +33,12 @@
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
             android:padding="1dp"
-            android:textSize="16sp"
-            android:textColor="#000">
+            style="@style/Base.TextAppearance.AppCompat.Body1"
+            android:textStyle="italic">
         </TextView>
     </LinearLayout>
     <ImageView android:id="@+id/diagram"
         android:layout_width="120dp"
-        android:layout_height="80dp"
-        android:scaleType="fitCenter" />
+        android:layout_height="88dp"
+        android:scaleType="fitEnd" />
 </LinearLayout>

--- a/app/src/main/res/layout/list_item.xml
+++ b/app/src/main/res/layout/list_item.xml
@@ -17,6 +17,12 @@
             android:textSize="20sp"
             android:textColor="#000"
             android:textStyle="bold">
+        <TextView
+            android:id="@+id/item_maori"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:padding="1dp"
+            style="@style/Base.TextAppearance.AppCompat.Subhead">
         </TextView>
         <TextView
             android:id="@+id/item_minor"


### PR DESCRIPTION
The search uses the Maori gloss as one of the primary search criteria, so it seems illogical to not show it in the results. Micky from NZSL has asked that we show the Maori gloss to make it easier to see matches, so I've added it here.

I also had a careful read of the [Material Design Guidelines re: lists](https://material.io/guidelines/components/lists.html#lists-specs) and have made some text appearance and spacing adjustments to the list item.

Note that merging this will break the build, as it depends on  the Android support library - the build will be fixed by merging the header PR.