### PR TITLE
Oops: Return more than four search results

### DIFF
--- a/app/app.iml
+++ b/app/app.iml
@@ -76,21 +76,15 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-safeguard" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/shaders" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/transforms" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
-      <excludeFolder url="file://$MODULE_DIR$/build/reports" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 25 Platform" jdkType="Android SDK" />

--- a/app/src/androidTest/java/DictionaryAndroidUnitTest.java
+++ b/app/src/androidTest/java/DictionaryAndroidUnitTest.java
@@ -42,9 +42,16 @@ public class DictionaryAndroidUnitTest {
     }
 
     @Test
+    public void dictionary_getWordsStartsWithMatchMainGlass() {
+        mResults = mDictionary.getWords("sunglasse");
+        assertEquals(mResults.get(0).gloss, "sunglasses");
+    }
+
+
+    @Test
     public void dictionary_getWordsContainsMatchMainGlass() {
         mResults = mDictionary.getWords("las");
-        assertEquals(mResults.get(0).gloss, "sunglasses");
+        assertEquals(mResults.get(0).gloss, "lasagna");
     }
 
     @Test
@@ -56,7 +63,13 @@ public class DictionaryAndroidUnitTest {
     @Test
     public void dictionary_getWordsContainsMatchMaoriGloss() {
         mResults = mDictionary.getWords("orang");
-        assertEquals(mResults.get(0).gloss, "politics");
+        assertEquals(mResults.get(0).gloss, "medical");
+    }
+
+    @Test
+    public void dictionary_getWordsStartsWithMatchMaoriGloss() {
+        mResults = mDictionary.getWords("Aorang");
+        assertEquals(mResults.get(0).gloss, "Feilding");
     }
 
     @Test
@@ -67,7 +80,7 @@ public class DictionaryAndroidUnitTest {
 
     @Test
     public void dictionary_getWordsContainsSecondaryGloss() {
-        mResults = mDictionary.getWords("keep ou");
+        mResults = mDictionary.getWords("avoid, keep");
         assertEquals(mResults.get(0).gloss, "want nothing to do with");
     }
 }

--- a/app/src/main/java/com/hewgill/android/nzsldict/Dictionary.java
+++ b/app/src/main/java/com/hewgill/android/nzsldict/Dictionary.java
@@ -1,6 +1,7 @@
 package com.hewgill.android.nzsldict;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 import android.util.Log;
 import java.io.BufferedReader;
 import java.io.InputStream;
@@ -29,7 +30,7 @@ public class Dictionary {
     private static final Integer EXACT_SECONDARY_MATCH_WEIGHTING = 70;
     private static final Integer CONTAINS_SECONDARY_MATCH_WEIGHTING = 60;
 
-    public static class DictItem implements Serializable {
+    public static class DictItem implements Serializable, Comparable {
         public String gloss;
         public String minor;
         public String maori;
@@ -105,6 +106,12 @@ public class Dictionary {
 
         public String toString() {
             return gloss + "|" + minor + "|" + maori;
+        }
+
+        @Override
+        public int compareTo(@NonNull Object o) {
+            DictItem other = (DictItem) o;
+            return this.gloss.compareTo(other.gloss);
         }
     }
 

--- a/app/src/main/java/com/hewgill/android/nzsldict/Dictionary.java
+++ b/app/src/main/java/com/hewgill/android/nzsldict/Dictionary.java
@@ -21,7 +21,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
 import java.util.TreeMap;
+import java.util.TreeSet;
 
 public class Dictionary {
 
@@ -178,6 +180,7 @@ public class Dictionary {
         // in. Because it is a sorted set, uniqueness is guaranteed, and results should also be
         // naturally ordered.
         SortedSet<DictItem> exactPrimaryMatches = new TreeSet<>();
+        SortedSet<DictItem> startsWithPrimaryMatches = new TreeSet<>();
         SortedSet<DictItem> containsPrimaryMatches = new TreeSet<>();
         SortedSet<DictItem> exactSecondaryMatches = new TreeSet<>();
         SortedSet<DictItem> containsSecondaryMatches = new TreeSet<>();
@@ -189,6 +192,7 @@ public class Dictionary {
             String maori = normalise(d.maori);
 
             if (gloss.equals(term) || maori.equals(term)) exactPrimaryMatches.add(d);
+            if (gloss.startsWith(term) || maori.startsWith(term)) startsWithPrimaryMatches.add(d);
             else if (gloss.contains(term) || maori.contains(term)) containsPrimaryMatches.add(d);
             else if (minor.equals(term)) exactSecondaryMatches.add(d);
             else if (minor.contains(term)) containsSecondaryMatches.add(d);
@@ -200,12 +204,14 @@ public class Dictionary {
         // Given: [exact: [e1, e2, e3], contains: [c1, c2, c2], exactSecondary: [es1, es2, es3]
         // Then: results = [e1, e2, e3, c1, c2, c3, es1, es2, es3]
         int resultCount = exactPrimaryMatches.size() +
+                          startsWithPrimaryMatches.size() +
                           containsPrimaryMatches.size() +
                           exactSecondaryMatches.size() +
                           containsSecondaryMatches.size();
 
         List<DictItem> results = new ArrayList<>(resultCount);
         results.addAll(exactPrimaryMatches);
+        results.addAll(startsWithPrimaryMatches);
         results.addAll(containsPrimaryMatches);
         results.addAll(exactSecondaryMatches);
         results.addAll(containsSecondaryMatches);

--- a/app/src/main/java/com/hewgill/android/nzsldict/Dictionary.java
+++ b/app/src/main/java/com/hewgill/android/nzsldict/Dictionary.java
@@ -3,10 +3,11 @@ package com.hewgill.android.nzsldict;
 import android.content.Context;
 import android.support.annotation.NonNull;
 import android.util.Log;
+
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.IOException;
 import java.io.Serializable;
 import java.security.MessageDigest;
 import java.text.Normalizer;
@@ -22,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
-import java.util.TreeMap;
 import java.util.TreeSet;
 
 public class Dictionary {
@@ -42,6 +42,7 @@ public class Dictionary {
         public String location;
 
         static Map<String, String> Locations = new HashMap<String, String>();
+
         static {
             Locations.put("in front of body", "location_1_1_in_front_of_body");
             //"palm",
@@ -66,7 +67,9 @@ public class Dictionary {
             Locations.put("upper arm", "location_5_16_upper_arm");
             Locations.put("elbow", "location_5_17_elbow");
             Locations.put("upper leg", "location_4_15_upper_leg");
-        };
+        }
+
+        ;
 
         public DictItem() {
             gloss = null;
@@ -119,8 +122,7 @@ public class Dictionary {
 
     private ArrayList<DictItem> words = new ArrayList();
 
-    public Dictionary(Context context)
-    {
+    public Dictionary(Context context) {
         InputStream db = null;
         try {
             db = context.getAssets().open("db/nzsl.dat");
@@ -155,13 +157,11 @@ public class Dictionary {
         });
     }
 
-    public List<DictItem> getWords()
-    {
+    public List<DictItem> getWords() {
         return words;
     }
 
-    private static String normalise(String s)
-    {
+    private static String normalise(String s) {
         s = Normalizer.normalize(s, Normalizer.Form.NFD);
         StringBuilder r = new StringBuilder(s.length());
         int len = s.length();
@@ -174,8 +174,7 @@ public class Dictionary {
         return r.toString().toLowerCase();
     }
 
-    public List<DictItem> getWords(String target)
-    {
+    public List<DictItem> getWords(String target) {
         // Create a sorted set for each type of match. This provides "buckets" to place results
         // in. Because it is a sorted set, uniqueness is guaranteed, and results should also be
         // naturally ordered.
@@ -186,7 +185,7 @@ public class Dictionary {
         SortedSet<DictItem> containsSecondaryMatches = new TreeSet<>();
 
         String term = normalise(target);
-        for (DictItem d: words) {
+        for (DictItem d : words) {
             String gloss = normalise(d.gloss);
             String minor = normalise(d.minor);
             String maori = normalise(d.maori);
@@ -204,10 +203,10 @@ public class Dictionary {
         // Given: [exact: [e1, e2, e3], contains: [c1, c2, c2], exactSecondary: [es1, es2, es3]
         // Then: results = [e1, e2, e3, c1, c2, c3, es1, es2, es3]
         int resultCount = exactPrimaryMatches.size() +
-                          startsWithPrimaryMatches.size() +
-                          containsPrimaryMatches.size() +
-                          exactSecondaryMatches.size() +
-                          containsSecondaryMatches.size();
+                startsWithPrimaryMatches.size() +
+                containsPrimaryMatches.size() +
+                exactSecondaryMatches.size() +
+                containsSecondaryMatches.size();
 
         List<DictItem> results = new ArrayList<>(resultCount);
         results.addAll(exactPrimaryMatches);
@@ -219,94 +218,92 @@ public class Dictionary {
         return results;
     }
 
-    public List<DictItem> getWordsByHandshape(String handshape, String location)
-    {
+    public List<DictItem> getWordsByHandshape(String handshape, String location) {
         List<DictItem> r = new ArrayList<DictItem>(words.size());
-        for (DictItem d: words) {
+        for (DictItem d : words) {
             if ((handshape == null || handshape.length() == 0 || d.handshape.equals(handshape))
-             && (location == null || location.length() == 0 || d.location.equals(location))) {
+                    && (location == null || location.length() == 0 || d.location.equals(location))) {
                 r.add(d);
             }
         }
         return r;
     }
 
-    static Set taboo = new HashSet(Arrays.asList(new String[] {
-        "(vaginal) discharge",
-        "abortion",
-        "abuse",
-        "anus",
-        "asshole",
-        "attracted",
-        "balls",
-        "been to",
-        "bisexual",
-        "bitch",
-        "blow job",
-        "breech (birth)",
-        "bugger",
-        "bullshit",
-        "cervical smear",
-        "cervix",
-        "circumcise",
-        "cold (behaviour)",
-        "come",
-        "condom",
-        "contraction (labour)",
-        "cunnilingus",
-        "cunt",
-        "damn",
-        "defecate, faeces",
-        "dickhead",
-        "dilate (cervix)",
-        "ejaculate, sperm",
-        "episiotomy",
-        "erection",
-        "fart",
-        "foreplay",
-        "gay",
-        "gender",
-        "get intimate",
-        "get stuffed",
-        "hard-on",
-        "have sex",
-        "heterosexual",
-        "homo",
-        "horny",
-        "hysterectomy",
-        "intercourse",
-        "labour pains",
-        "lesbian",
-        "lose one's virginity",
-        "love bite",
-        "lust",
-        "masturbate (female)",
-        "masturbate, wanker",
-        "miscarriage",
-        "orgasm",
-        "ovaries",
-        "penis",
-        "period",
-        "period pains",
-        "promiscuous",
-        "prostitute",
-        "rape",
-        "sanitary pad",
-        "sex",
-        "sexual abuse",
-        "shit",
-        "smooch",
-        "sperm",
-        "strip",
-        "suicide",
-        "tampon",
-        "testicles",
-        "vagina",
-        "virgin",
+    static Set taboo = new HashSet(Arrays.asList(new String[]{
+            "(vaginal) discharge",
+            "abortion",
+            "abuse",
+            "anus",
+            "asshole",
+            "attracted",
+            "balls",
+            "been to",
+            "bisexual",
+            "bitch",
+            "blow job",
+            "breech (birth)",
+            "bugger",
+            "bullshit",
+            "cervical smear",
+            "cervix",
+            "circumcise",
+            "cold (behaviour)",
+            "come",
+            "condom",
+            "contraction (labour)",
+            "cunnilingus",
+            "cunt",
+            "damn",
+            "defecate, faeces",
+            "dickhead",
+            "dilate (cervix)",
+            "ejaculate, sperm",
+            "episiotomy",
+            "erection",
+            "fart",
+            "foreplay",
+            "gay",
+            "gender",
+            "get intimate",
+            "get stuffed",
+            "hard-on",
+            "have sex",
+            "heterosexual",
+            "homo",
+            "horny",
+            "hysterectomy",
+            "intercourse",
+            "labour pains",
+            "lesbian",
+            "lose one's virginity",
+            "love bite",
+            "lust",
+            "masturbate (female)",
+            "masturbate, wanker",
+            "miscarriage",
+            "orgasm",
+            "ovaries",
+            "penis",
+            "period",
+            "period pains",
+            "promiscuous",
+            "prostitute",
+            "rape",
+            "sanitary pad",
+            "sex",
+            "sexual abuse",
+            "shit",
+            "smooch",
+            "sperm",
+            "strip",
+            "suicide",
+            "tampon",
+            "testicles",
+            "vagina",
+            "virgin",
     }));
 
-    public DictItem getWordOfTheDay()
-    {
+    public DictItem getWordOfTheDay() {
         String buf = new SimpleDateFormat("yyyy-MM-dd").format(new Date());
         try {
             byte[] digest = MessageDigest.getInstance("SHA-1").digest(buf.getBytes());
@@ -321,12 +318,11 @@ public class Dictionary {
         }
     }
 
-    private String skip_parens(String s)
-    {
+    private String skip_parens(String s) {
         if (s.charAt(0) == '(') {
             int i = s.indexOf(") ");
             if (i > 0) {
-                s = s.substring(i+2);
+                s = s.substring(i + 2);
             } else {
                 Log.d("Dictionary", "expected to find closing parenthesis: " + s);
             }

--- a/app/src/main/java/com/hewgill/android/nzsldict/Dictionary.java
+++ b/app/src/main/java/com/hewgill/android/nzsldict/Dictionary.java
@@ -174,12 +174,6 @@ public class Dictionary {
 
     public List<DictItem> getWords(String target)
     {
-        TreeMap<Integer, DictItem> results = new TreeMap<Integer, DictItem>(new Comparator<Integer>() {
-            @Override
-            public int compare(Integer weight1, Integer weight2) {
-                return weight2.compareTo(weight1);
-            }
-        });
         String term = normalise(target);
         for (DictItem d: words) {
             String gloss = normalise(d.gloss);


### PR DESCRIPTION
Unfortunately, when I was building the search results, I fundamentally failed to understand that a `TreeMap` is very similar to a `Hash` - once a key exists, setting it again will just overwrite the value. Since I was using the search weightings as the keys, I was never returning more than 4 results. My git commits have more information about the depth of my screwup.

