### PR TITLE
Adjustments to spacing and typography for handshape search

### DIFF
--- a/app/src/main/res/drawable/handshape_item.xml
+++ b/app/src/main/res/drawable/handshape_item.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_selected="true"
+          android:drawable="@drawable/handshape_item_selected" />
+
+</selector>

--- a/app/src/main/res/drawable/handshape_item_selected.xml
+++ b/app/src/main/res/drawable/handshape_item_selected.xml
@@ -1,0 +1,5 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle" >
+    <solid android:color="@android:color/white" />
+    <stroke android:width="2dp" android:color="@color/primaryDark"/>
+    <corners android:radius="4dp" />
+</shape>

--- a/app/src/main/res/layout/handshape.xml
+++ b/app/src/main/res/layout/handshape.xml
@@ -2,6 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical"
     android:layout_width="fill_parent"
+    android:paddingBottom="24dp"
     android:layout_height="wrap_content">
     <LinearLayout android:id="@+id/handshape_header"
         android:orientation="vertical"
@@ -10,24 +11,33 @@
         <TextView
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:textColor="#000"
-            android:background="#eee"
-            android:textSize="18sp"
+            android:textAppearance="@style/Base.TextAppearance.AppCompat.Body2"
+            android:textColor="@color/secondary_text_default_material_light"
+            android:padding="16dp"
             android:text="Handshape" />
         <Gallery android:id="@+id/handshape"
             android:layout_width="fill_parent"
+            android:background="@android:color/white"
             android:layout_height="wrap_content"
-            android:spacing="20px" />
+            android:padding="16dp"
+            android:spacing="16dp" />
         <TextView
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:textColor="#000"
-            android:background="#eee"
-            android:textSize="18sp"
+            android:textAppearance="@style/Base.TextAppearance.AppCompat.Body2"
+            android:textColor="@color/secondary_text_default_material_light"
+            android:padding="8dp"
             android:text="Location" />
         <Gallery android:id="@+id/location"
             android:layout_width="fill_parent"
+            android:background="@android:color/white"
             android:layout_height="wrap_content"
-            android:spacing="20px" />
+            android:padding="16dp"
+            android:spacing="8dp" />
     </LinearLayout>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/twelve_percent_black" />
 </LinearLayout>

--- a/app/src/main/res/layout/handshape_item.xml
+++ b/app/src/main/res/layout/handshape_item.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
+    android:background="@drawable/handshape_item"
+    android:padding="4dp"
     android:layout_height="wrap_content">
     <TextView
         android:id="@+id/handshape_label"
@@ -13,5 +15,5 @@
         android:id="@+id/handshape_item"
         android:layout_width="100sp"
         android:layout_height="100sp"
-        android:background="#fff" />
+        />
 </RelativeLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <color name="primary">#2980B9</color><!--Background color for AppBar-->
     <color name="accent">#F57958</color><!--color effects, EditText, RadioButtons...-->
     <color name="primaryDark">#18435F</color>
     <color name="textColorPrimary">@android:color/white</color>
+
+    <!-- Overridden from https://chromium.googlesource.com/android_tools/+/master/sdk/extras/android/support/v7/appcompat/res/values/colors_material.xml -->
+    <color tools:override="true" name="secondary_text_default_material_light">#8a000000</color>
+
+    <color name="twelve_percent_black">#1f000000</color>
 </resources>


### PR DESCRIPTION
A screenshot says 1,000 words:

![nzsl-handshape-search-1](https://user-images.githubusercontent.com/292020/27019889-5fa2c2a4-4f90-11e7-97b7-158f003092ab.png)

It's amazing the difference some colour and font size changes make, eh.