### PR TITLE
Remove duplicates from keyword search results

### DIFF
--- a/app/src/androidTest/java/DictionaryAndroidUnitTest.java
+++ b/app/src/androidTest/java/DictionaryAndroidUnitTest.java
@@ -2,12 +2,14 @@ import android.support.test.filters.SmallTest;
 import android.support.test.runner.AndroidJUnit4;
 
 import com.hewgill.android.nzsldict.Dictionary;
+import com.hewgill.android.nzsldict.Dictionary.DictItem;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static android.support.test.InstrumentationRegistry.getInstrumentation;
@@ -18,7 +20,7 @@ import static org.junit.Assert.assertNotEquals;
 @SmallTest
 public class DictionaryAndroidUnitTest {
     private Dictionary mDictionary;
-    private List<Dictionary.DictItem> mResults;
+    private List<DictItem> mResults;
 
     @Before
     public void createDictionary() {
@@ -82,5 +84,19 @@ public class DictionaryAndroidUnitTest {
     public void dictionary_getWordsContainsSecondaryGloss() {
         mResults = mDictionary.getWords("avoid, keep");
         assertEquals(mResults.get(0).gloss, "want nothing to do with");
+    }
+
+    @Test
+    public void dictionary_getWordsRemovesDuplicatesFromMatchGroups() {
+        mResults = mDictionary.getWords("Auckland");
+        List<DictItem> resultsThatAreAuckland = new ArrayList<>();
+
+        for (DictItem di : mResults) {
+            if (di.gloss.equals("Auckland")) resultsThatAreAuckland.add(di);
+        }
+
+        // The term 'Auckland' matches both an exact match and has few enough results it appears
+        // as a 'starts with'. If duplicate detection is working, the sign should appear only once.
+        assertEquals(resultsThatAreAuckland.size(), 1);
     }
 }

--- a/app/src/main/java/com/hewgill/android/nzsldict/Dictionary.java
+++ b/app/src/main/java/com/hewgill/android/nzsldict/Dictionary.java
@@ -19,6 +19,7 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -174,7 +175,7 @@ public class Dictionary {
         return r.toString().toLowerCase();
     }
 
-    public List<DictItem> getWords(String target) {
+    public ArrayList<DictItem> getWords(String target) {
         // Create a sorted set for each type of match. This provides "buckets" to place results
         // in. Because it is a sorted set, uniqueness is guaranteed, and results should also be
         // naturally ordered.
@@ -208,14 +209,17 @@ public class Dictionary {
                 exactSecondaryMatches.size() +
                 containsSecondaryMatches.size();
 
-        List<DictItem> results = new ArrayList<>(resultCount);
+        LinkedHashSet<DictItem> results = new LinkedHashSet<>(resultCount);
         results.addAll(exactPrimaryMatches);
         results.addAll(startsWithPrimaryMatches);
         results.addAll(containsPrimaryMatches);
         results.addAll(exactSecondaryMatches);
         results.addAll(containsSecondaryMatches);
 
-        return results;
+        ArrayList<DictItem> indexAccessibleCollection = new ArrayList<>();
+        indexAccessibleCollection.addAll(results);
+
+        return indexAccessibleCollection;
     }
 
     public List<DictItem> getWordsByHandshape(String handshape, String location) {


### PR DESCRIPTION
Apparently Java is all about picking the right kind of collection. I'm
definitely not being very considerate of system resources here, but it
does work.

We were using an ArrayList to collate results, which does not enforce
any uniqueness. For search results that had signs that matched in more
than one way (e.g. equals, starts with), the sign would show up twice.
To fix this, I've moved to collating results to a LinkedHashSet, which
enforces uniqueness (first in wins). I experimented with passing the set
back to the activity, but this did not work as the Set interface does
not expose a method to get an item by index, and both the activity and
underlying tests use this method.