### PR TITLE
Match for equality on image, not gloss.

### DIFF
--- a/app/src/main/java/com/hewgill/android/nzsldict/Dictionary.java
+++ b/app/src/main/java/com/hewgill/android/nzsldict/Dictionary.java
@@ -114,10 +114,11 @@ public class Dictionary {
             return gloss + "|" + minor + "|" + maori;
         }
 
+        
         @Override
         public int compareTo(@NonNull Object o) {
             DictItem other = (DictItem) o;
-            return this.gloss.compareTo(other.gloss);
+            return this.image.compareTo(other.image);
         }
     }
 


### PR DESCRIPTION
The same gloss can be repeated while being unique (for example, 'Auckland' has several variations. I
think the image path is the best attribute to match on. Note that this may break alphabetic sorting within results, but I don't think this is vitally important.