### PR TITLE
Improve behaviour and layout of video player

### DIFF
--- a/app/app.iml
+++ b/app/app.iml
@@ -22,7 +22,7 @@
       </configuration>
     </facet>
   </component>
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output url="file://$MODULE_DIR$/build/intermediates/classes/debug" />
     <output-test url="file://$MODULE_DIR$/build/intermediates/classes/test/debug" />
     <content url="file://$MODULE_DIR$">
@@ -61,13 +61,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
@@ -75,6 +68,13 @@
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/builds" />
@@ -103,35 +103,35 @@
     </content>
     <orderEntry type="jdk" jdkName="Android API 25 Platform (1)" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" exported="" scope="TEST" name="runner-0.5" level="project" />
-    <orderEntry type="library" exported="" scope="TEST" name="espresso-idling-resource-2.2.2" level="project" />
-    <orderEntry type="library" exported="" scope="TEST" name="hamcrest-library-1.3" level="project" />
-    <orderEntry type="library" exported="" name="transition-25.3.1" level="project" />
-    <orderEntry type="library" exported="" scope="TEST" name="hamcrest-integration-1.3" level="project" />
-    <orderEntry type="library" exported="" name="design-25.3.1" level="project" />
-    <orderEntry type="library" exported="" name="support-core-ui-25.3.1" level="project" />
-    <orderEntry type="library" exported="" name="cardview-v7-25.3.1" level="project" />
-    <orderEntry type="library" exported="" scope="TEST" name="jsr305-2.0.1" level="project" />
-    <orderEntry type="library" exported="" name="support-core-utils-25.3.1" level="project" />
-    <orderEntry type="library" exported="" name="support-fragment-25.3.1" level="project" />
-    <orderEntry type="library" exported="" scope="TEST" name="espresso-core-2.2.2" level="project" />
-    <orderEntry type="library" exported="" scope="TEST" name="exposed-instrumentation-api-publish-0.5" level="project" />
-    <orderEntry type="library" exported="" scope="TEST" name="rules-0.5" level="project" />
-    <orderEntry type="library" exported="" scope="TEST" name="espresso-web-2.2.2" level="project" />
-    <orderEntry type="library" exported="" scope="TEST" name="tagsoup-1.2" level="project" />
-    <orderEntry type="library" exported="" scope="TEST" name="javax.annotation-api-1.2" level="project" />
-    <orderEntry type="library" exported="" scope="TEST" name="javax.inject-1" level="project" />
-    <orderEntry type="library" exported="" scope="TEST" name="javawriter-2.1.1" level="project" />
-    <orderEntry type="library" exported="" name="support-v4-25.3.1" level="project" />
-    <orderEntry type="library" exported="" name="support-media-compat-25.3.1" level="project" />
-    <orderEntry type="library" exported="" scope="TEST" name="hamcrest-core-1.3" level="project" />
-    <orderEntry type="library" exported="" name="calligraphy-2.3.0" level="project" />
-    <orderEntry type="library" exported="" scope="TEST" name="junit-4.12" level="project" />
-    <orderEntry type="library" exported="" name="recyclerview-v7-25.3.1" level="project" />
-    <orderEntry type="library" exported="" name="support-annotations-25.3.1" level="project" />
-    <orderEntry type="library" exported="" name="appcompat-v7-25.3.1" level="project" />
-    <orderEntry type="library" exported="" name="support-vector-drawable-25.3.1" level="project" />
-    <orderEntry type="library" exported="" name="support-compat-25.3.1" level="project" />
-    <orderEntry type="library" exported="" name="animated-vector-drawable-25.3.1" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="com.android.support.test:exposed-instrumentation-api-publish-0.5" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="junit:junit:4.12@jar" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="org.ccil.cowan.tagsoup:tagsoup:1.2@jar" level="project" />
+    <orderEntry type="library" exported="" name="com.android.support:cardview-v7-25.3.1" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="javax.inject:javax.inject:1@jar" level="project" />
+    <orderEntry type="library" exported="" name="com.android.support:support-core-ui-25.3.1" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="com.squareup:javawriter:2.1.1@jar" level="project" />
+    <orderEntry type="library" exported="" name="com.android.support:support-compat-25.3.1" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="com.android.support.test.espresso:espresso-web-2.2.2" level="project" />
+    <orderEntry type="library" exported="" name="com.android.support:support-core-utils-25.3.1" level="project" />
+    <orderEntry type="library" exported="" name="com.android.support:support-v4-25.3.1" level="project" />
+    <orderEntry type="library" exported="" name="com.android.support:support-fragment-25.3.1" level="project" />
+    <orderEntry type="library" exported="" name="com.android.support:support-media-compat-25.3.1" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="com.google.code.findbugs:jsr305:2.0.1@jar" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="org.hamcrest:hamcrest-core:1.3@jar" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="com.android.support.test.espresso:espresso-core-2.2.2" level="project" />
+    <orderEntry type="library" exported="" name="com.android.support:animated-vector-drawable-25.3.1" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="com.android.support.test:rules-0.5" level="project" />
+    <orderEntry type="library" exported="" name="com.android.support:transition-25.3.1" level="project" />
+    <orderEntry type="library" exported="" name="com.android.support:design-25.3.1" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="org.hamcrest:hamcrest-library:1.3@jar" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="org.hamcrest:hamcrest-integration:1.3@jar" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="com.android.support.test:runner-0.5" level="project" />
+    <orderEntry type="library" exported="" name="com.android.support:appcompat-v7-25.3.1" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="com.android.support.test.espresso:espresso-idling-resource-2.2.2" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="javax.annotation:javax.annotation-api:1.2@jar" level="project" />
+    <orderEntry type="library" exported="" name="com.android.support:support-vector-drawable-25.3.1" level="project" />
+    <orderEntry type="library" exported="" name="uk.co.chrisjenx:calligraphy-2.3.0" level="project" />
+    <orderEntry type="library" exported="" name="com.android.support:recyclerview-v7-25.3.1" level="project" />
+    <orderEntry type="library" exported="" name="com.android.support:support-annotations:25.3.1@jar" level="project" />
   </component>
 </module>

--- a/app/src/main/java/com/hewgill/android/nzsldict/SignVideoFragment.java
+++ b/app/src/main/java/com/hewgill/android/nzsldict/SignVideoFragment.java
@@ -145,7 +145,15 @@ public class SignVideoFragment extends Fragment {
         return activeNetworkInfo != null && activeNetworkInfo.isConnected();
     }
 
+    public void showControls() {
+        mVideo.setVisibility(View.VISIBLE);
+        mMediaController.show();
+    }
 
+    public void stop() {
+        mVideo.stopPlayback();
+        mVideo.setVisibility(View.INVISIBLE);
+        mMediaController.hide();
     }
 
 }

--- a/app/src/main/java/com/hewgill/android/nzsldict/SignVideoFragment.java
+++ b/app/src/main/java/com/hewgill/android/nzsldict/SignVideoFragment.java
@@ -41,7 +41,7 @@ public class SignVideoFragment extends Fragment {
     private View mRootView;
     private boolean mMediaControllerLaidOut = false;
     private Dictionary.DictItem mDictItem;
-    private NoHideMediaController mMediaController;
+    private MediaController mMediaController;
     private View mNoNetworkFrame;
     private IntentFilter mConnectivityIntentFilter = new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION);
     private BroadcastReceiver mConnectivityChangeReceiver = new BroadcastReceiver() {
@@ -74,7 +74,7 @@ public class SignVideoFragment extends Fragment {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        mMediaController = new NoHideMediaController(getContext());
+        mMediaController = new MediaController(getContext());
         if (getArguments() != null) {
             mDictItem = (Dictionary.DictItem) getArguments().getSerializable(ARG_DICT_ITEM);
         }
@@ -123,7 +123,7 @@ public class SignVideoFragment extends Fragment {
         });
         mVideo.setOnPreparedListener(new MediaPlayer.OnPreparedListener() {
             public void onPrepared(MediaPlayer mp) {
-                fixLayoutOfMediaController();
+                mVideo.setMediaController(mMediaController);
             }
         });
 
@@ -134,22 +134,6 @@ public class SignVideoFragment extends Fragment {
     }
 
 
-    private void fixLayoutOfMediaController() {
-        if (mMediaControllerLaidOut) return;
-        RelativeLayout parentLayout = (RelativeLayout) mVideo.getParent();
-        FrameLayout frameLayout = (FrameLayout) mMediaController.getParent();
-        RelativeLayout.LayoutParams layoutParams = new RelativeLayout.LayoutParams(
-                RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.WRAP_CONTENT);
-        layoutParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM, this.getId());
-
-        ((LinearLayout)frameLayout.getParent()).removeView(frameLayout);
-        parentLayout.addView(frameLayout, layoutParams);
-
-        mMediaController.setAnchorView(mVideo);
-        mVideo.setMediaController(mMediaController);
-        mMediaController.hide();
-        mMediaControllerLaidOut = true;
-    }
 
     private boolean isNetworkAvailable() {
         ConnectivityManager connectivityManager
@@ -158,26 +142,7 @@ public class SignVideoFragment extends Fragment {
         return activeNetworkInfo != null && activeNetworkInfo.isConnected();
     }
 
-    class NoHideMediaController extends MediaController {
-        public NoHideMediaController(Context context) {
-            super(context);
-        }
 
-        // http://stackoverflow.com/questions/6051825/android-back-button-and-mediacontroller
-        @Override
-        public boolean dispatchKeyEvent(KeyEvent event) {
-            if (event.getKeyCode() == KeyEvent.KEYCODE_BACK) {
-                ((Activity) getContext()).finish();
-                return true;
-            }
-            return super.dispatchKeyEvent(event);
-        }
-
-        // http://stackoverflow.com/questions/6651718/keeping-mediacontroller-on-the-screen-in-a-videoview
-        @Override
-        public void hide() {
-            show(0);
-        }
     }
 
 }

--- a/app/src/main/java/com/hewgill/android/nzsldict/SignVideoFragment.java
+++ b/app/src/main/java/com/hewgill/android/nzsldict/SignVideoFragment.java
@@ -39,6 +39,7 @@ public class SignVideoFragment extends Fragment {
     private static final String ARG_DICT_ITEM = "dictItem";
     private VideoView mVideo;
     private View mRootView;
+    private View mAnchorView;
     private boolean mMediaControllerLaidOut = false;
     private Dictionary.DictItem mDictItem;
     private MediaController mMediaController;
@@ -111,6 +112,7 @@ public class SignVideoFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
          mRootView = inflater.inflate(R.layout.fragment_sign_video, container, false);
+         mAnchorView = mRootView.findViewById(R.id.sign_video_anchor);
 
         mVideo = (VideoView) mRootView.findViewById(R.id.sign_video);
         mNoNetworkFrame = mRootView.findViewById(R.id.sign_video_network_unavailable);
@@ -124,6 +126,7 @@ public class SignVideoFragment extends Fragment {
         mVideo.setOnPreparedListener(new MediaPlayer.OnPreparedListener() {
             public void onPrepared(MediaPlayer mp) {
                 mVideo.setMediaController(mMediaController);
+                mMediaController.setAnchorView(mAnchorView);
             }
         });
 

--- a/app/src/main/java/com/hewgill/android/nzsldict/WordActivity.java
+++ b/app/src/main/java/com/hewgill/android/nzsldict/WordActivity.java
@@ -17,6 +17,7 @@ public class WordActivity extends BaseActivity {
     private TextView gloss;
     private TextView minor;
     private TextView maori;
+    private SignVideoFragment mVideoFragment;
     private ViewPager viewPager;
     private Dictionary.DictItem item;
 
@@ -44,7 +45,9 @@ public class WordActivity extends BaseActivity {
     private void setupSignMediaPager(ViewPager viewPager) {
         ViewPagerAdapter adapter = new ViewPagerAdapter(getSupportFragmentManager());
         adapter.addFragment(SignIllustrationFragment.newInstance(item), "Illustration");
-        adapter.addFragment(SignVideoFragment.newInstance(item), "Video");
+        mVideoFragment = SignVideoFragment.newInstance(item);
+        adapter.addFragment(mVideoFragment, "Video");
+        viewPager.addOnPageChangeListener(new WordPageChangeListener(viewPager));
         viewPager.setAdapter(adapter);
     }
 
@@ -74,6 +77,32 @@ public class WordActivity extends BaseActivity {
         @Override
         public CharSequence getPageTitle(int position) {
             return mFragmentTitleList.get(position);
+        }
+    }
+
+    private class WordPageChangeListener implements ViewPager.OnPageChangeListener {
+        private final ViewPager mPager;
+
+        private WordPageChangeListener(ViewPager pager) {
+            mPager = pager;
+        }
+        @Override
+        public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
+        }
+
+        @Override
+        public void onPageSelected(int position) {
+            ViewPagerAdapter vpa = (ViewPagerAdapter) mPager.getAdapter();
+            if (vpa.getPageTitle(position).equals("Video")) {
+                mVideoFragment.showControls();
+            } else {
+                mVideoFragment.stop();
+            }
+        }
+
+        @Override
+        public void onPageScrollStateChanged(int state) {
+
         }
     }
 }

--- a/app/src/main/res/layout/fragment_sign_video.xml
+++ b/app/src/main/res/layout/fragment_sign_video.xml
@@ -5,13 +5,19 @@
     android:layout_width="fill_parent"
     android:background="@android:color/black"
     android:layout_height="wrap_content">
-    <VideoView
-        android:id="@+id/sign_video"
-        android:layout_width="fill_parent"
-        android:gravity="center"
-        android:layout_height="wrap_content"
-        android:scaleType="fitCenter"
-     />
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/sign_video_anchor">
+        <VideoView
+            android:id="@+id/sign_video"
+            android:layout_width="fill_parent"
+            android:gravity="center"
+            android:layout_height="wrap_content"
+            android:scaleType="fitCenter"
+         />
+    </FrameLayout>
 
     <LinearLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
We've had a few pieces of feedback over the last couple of months regarding the video player controls appearing over the top of the video content and causing issues:

> I thought I'd pass on that when playing videos demonstrating how to sign the words in the NZSL app the play/rewind/fast forward menu often sits over the signers hands and can't be minimised so I cant see the sign in action at all.

> Android back button does not work on latest NZSL Android app version

This pull request implements what I think is the best solution for this, which is to let Android decide when to hide the video controls so as to not obstruct the video. I have also included a change to the layout so that the video controls are shown at the bottom of the screen where screen height allows, and fixed some rendering issues that occur when swiping between tabs while the video is playing.

Screenshots:

![screenshot_1512693774](https://user-images.githubusercontent.com/292020/33746275-091b85ce-dc21-11e7-819b-1840d59bd8d7.png)
![screenshot_1512693778](https://user-images.githubusercontent.com/292020/33746276-094509d0-dc21-11e7-8f0c-a1e612d52d9b.png)
![screenshot_1512693784](https://user-images.githubusercontent.com/292020/33746277-096fc74c-dc21-11e7-952b-bf207bf0b6c2.png)
![screenshot_1512693955](https://user-images.githubusercontent.com/292020/33746278-09991a5c-dc21-11e7-8077-32246b51318f.png)
