### PR TITLE
Zendesk 393: Handle missing sign images

### DIFF
--- a/app/app.iml
+++ b/app/app.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":app" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" version="4">
+<module external.linked.project.id=":app" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="android-gradle" name="Android-Gradle">
       <configuration>
@@ -25,6 +25,7 @@
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output url="file://$MODULE_DIR$/build/intermediates/classes/debug" />
     <output-test url="file://$MODULE_DIR$/build/intermediates/classes/test/debug" />
+    <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/debug" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/debug" isTestSource="false" generated="true" />
@@ -61,13 +62,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
@@ -75,6 +69,14 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/build/.DS_Store" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/builds" />

--- a/app/src/androidTest/java/DictionaryAndroidUnitTest.java
+++ b/app/src/androidTest/java/DictionaryAndroidUnitTest.java
@@ -105,7 +105,7 @@ public class DictionaryAndroidUnitTest {
     public void dictionaryItem_imagePathHandlesMissingImage() {
         DictItem di = new DictItem();
         di.image = "";
-        assertNull(di.imagePath(), "When the image is missing, NULL is returned");
+        assertEquals(di.imagePath(), "", "When the image is missing, an empty string is returned");
     }
 
     @Test

--- a/app/src/androidTest/java/DictionaryAndroidUnitTest.java
+++ b/app/src/androidTest/java/DictionaryAndroidUnitTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 import static android.support.test.InstrumentationRegistry.getInstrumentation;
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNull;
 import static org.junit.Assert.assertNotEquals;
 
 @RunWith(AndroidJUnit4.class)
@@ -98,5 +99,20 @@ public class DictionaryAndroidUnitTest {
         // The term 'Auckland' matches both an exact match and has few enough results it appears
         // as a 'starts with'. If duplicate detection is working, the sign should appear only once.
         assertEquals(resultsThatAreAuckland.size(), 1);
+    }
+
+    @Test
+    public void dictionaryItem_imagePathHandlesMissingImage() {
+        DictItem di = new DictItem();
+        di.image = "";
+        assertNull(di.imagePath(), "When the image is missing, NULL is returned");
+    }
+
+    @Test
+    public void dictionaryItem_imagePathHandlesRegularImage() {
+        DictItem di = new DictItem();
+        di.image = "picture_w30_6739.png";
+        String expectedPath = "images/signs/picture_w30_6739.png";
+        assertEquals(di.imagePath(), expectedPath);
     }
 }

--- a/app/src/main/java/com/hewgill/android/nzsldict/Dictionary.java
+++ b/app/src/main/java/com/hewgill/android/nzsldict/Dictionary.java
@@ -96,6 +96,7 @@ public class Dictionary {
             String base = image.substring(0, image.length() - 4);
             String name = "images/signs/" + base.toLowerCase().replaceAll("[-.]", "_") + ".png";
             return name;
+            if (image.isEmpty()) return null;
         }
 
         public String handshapeImage() {

--- a/app/src/main/java/com/hewgill/android/nzsldict/Dictionary.java
+++ b/app/src/main/java/com/hewgill/android/nzsldict/Dictionary.java
@@ -96,7 +96,7 @@ public class Dictionary {
             String base = image.substring(0, image.length() - 4);
             String name = "images/signs/" + base.toLowerCase().replaceAll("[-.]", "_") + ".png";
             return name;
-            if (image.isEmpty()) return null;
+            if (image.isEmpty()) return "";
         }
 
         public String handshapeImage() {

--- a/app/src/main/java/com/hewgill/android/nzsldict/Dictionary.java
+++ b/app/src/main/java/com/hewgill/android/nzsldict/Dictionary.java
@@ -93,10 +93,9 @@ public class Dictionary {
         }
 
         public String imagePath() {
-            String base = image.substring(0, image.length() - 4);
-            String name = "images/signs/" + base.toLowerCase().replaceAll("[-.]", "_") + ".png";
-            return name;
             if (image.isEmpty()) return "";
+            String assetName = "images/signs/" + image.toLowerCase();
+            return assetName;
         }
 
         public String handshapeImage() {

--- a/app/src/main/java/com/hewgill/android/nzsldict/NZSLDictionary.java
+++ b/app/src/main/java/com/hewgill/android/nzsldict/NZSLDictionary.java
@@ -100,6 +100,7 @@ public class NZSLDictionary extends AppCompatActivity {
                 Drawable d = Drawable.createFromStream(ims, null);
                 dv.setImageDrawable(d);
             } catch (IOException e) {
+                dv.setImageDrawable(null);
                 System.out.println(e.toString());
             }
             return v;

--- a/nzsl-dictionary-android.iml
+++ b/nzsl-dictionary-android.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="nzsl-dictionary-android" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="nzsl-dictionary-android" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="java-gradle" name="Java-Gradle">
       <configuration>
@@ -13,7 +13,7 @@
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.gradle" />
     </content>
-    <orderEntry type="jdk" jdkName="1.8" jdkType="JavaSDK" />
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>


### PR DESCRIPTION
Addresses a bug relating to the sign for "Tolaga Bay" sign. This sign was exported from Freelex without a corresponding sign image, causing a crash in the Android application when it attempts to derive the path to the (missing) image.

This change first guards against missing images (an empty string is returned in this case to cause the code to execute an existing code path for general image load failure), and also removes code that has been made redundant by our addition of image filename preprocessing in [nzsl-dictionary-scripts](https://github.com/rabid/nzsl-dictionary-scripts/blob/7d5b8ad15f1b605229df3aaf8c452a9f2ff34c9d/freelex.py#L36). 